### PR TITLE
Add secondary font stack and buttons

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -58,8 +58,8 @@ h1.heading-xlarge{margin-top:40px; margin-bottom:20px;}
 }
 
 // Font Overrides
-*:not(.token) { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; }
-#proposition-name { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif !important; }
+*:not(.token) { font-family: $Helvetica-Regular !important; }
+#proposition-name { font-family: $Helvetica-Regular !important; }
 .example * {
   font-family: 'nta', Helvetica, Arial, sans-serif !important;
 }

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -63,3 +63,9 @@ h1.heading-xlarge{margin-top:40px; margin-bottom:20px;}
 .example * {
   font-family: 'nta', Helvetica, Arial, sans-serif !important;
 }
+
+// Secondary button
+.button-secondary {
+  @include button($grey-3);
+  padding: em(10) em(15) em(5) em(15);
+}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -363,6 +363,16 @@
         in the DWP pattern library for sub-navigation in a staff-facing service.
       </p>
 
+      <h3 class="heading-medium">Buttons</h3>
+      <p>
+        We should aim to use only one button per page in the primary <a href="http://govuk-elements.herokuapp.com/buttons/">GOV.UK style</a>.
+        If a secondary button style is needed, we should be consistent across services, taking contrast into consideraton.
+      </p>
+
+      <div class="example">
+        <input type="button" class="button button-secondary" value="Secondary" />
+      </div>
+
       <h3 class="heading-medium">Icons</h3>
       <p>
         Use icons sparingly on public-facing services. You may find them more


### PR DESCRIPTION
During the show and tell it was clear that we are inconsistent with our secondary button styles. One of the examples shown was invisible when viewed via the projector. Not everyones screen will have great contrast and we should take this into consideration. This is something we can recommend as part of the element guidelines.
